### PR TITLE
Weekly frontend 0.1.5 - fix for #469

### DIFF
--- a/static/js/viewer/views.js
+++ b/static/js/viewer/views.js
@@ -18,6 +18,7 @@ storybase.viewer.views.ViewerApp = Backbone.View.extend({
   events: function() {
     var events = {};
     events['click ' + this.options.tocButtonEl] = 'toggleToc';
+    events['resize figure img'] = 'handleImgResize';
     return events;
   },
 
@@ -44,6 +45,7 @@ storybase.viewer.views.ViewerApp = Backbone.View.extend({
     this.navigationView.render();
     this.$('.summary').show();
     this.$('.section').show();
+    this.sizeFigCaptions();
     return this;
   },
 
@@ -85,6 +87,29 @@ storybase.viewer.views.ViewerApp = Backbone.View.extend({
   // Event handler for scroll event
   handleScroll: function(e) {
     // Do nothing. Subclasses might want to implement this to do some work
+  },
+  
+  sizeFigCaptionForImg: function(imgEl) {
+    $(imgEl).next('figcaption').width($(imgEl).width());
+  },
+  
+  sizeFigCaptions: function() {
+    // we don't seem to get load events on images
+    // even under a hard refresh.
+    var view = this;
+    this.$('figure img').each(function() {
+      if (this.width) {
+        view.sizeFigCaptionForImg(this);
+      }
+      // however, set up a handler anyway.
+      $(this).on('load', function() {
+        view.sizeFigCaptionForImg(this);
+      });
+    });
+  },
+  
+  handleImgResize: function(event) {
+    this.sizeFigCaptionForImg(event.target);
   },
 
   toggleToc: function(evt) {


### PR DESCRIPTION
contains fix for #469. so much for that being bite-sized. was unable to capture img load events. they 1. don't bubble and 2. aren't sent if the images are already loaded, which seemed to be happening, even under a hard refresh.
