### PR TITLE
Don't defer every src load in builder (#800).

### DIFF
--- a/static/js/builder/views.js
+++ b/static/js/builder/views.js
@@ -4628,7 +4628,7 @@
           }
           else {
             storybase.views.deferSrcLoad({
-              assetSelector: 'iframe.sandboxed-asset',
+              selector: 'iframe.sandboxed-asset',
               scope: this.$el
             });
           }


### PR DESCRIPTION
The deferSrcLoad method takes "selector" as option key, rather than
"assetSelector". It was therefore selecting the default "*[src]".
Cross-checked against #187 test cases.
