### PR TITLE
Fix poorly-merged event declaration (#804).

### DIFF
--- a/static/js/viewer/views.js
+++ b/static/js/viewer/views.js
@@ -44,7 +44,6 @@
 
       events: function() {
         var events = {
-          'resize figure img': 'handleImgResize',
           'click a.external': openInNewWindow
         };
         events['click ' + this.options.tocButtonEl] = 'toggleToc';


### PR DESCRIPTION
A merge reintroduced an event declaration in the viewer for a
function which no longer exists. Take that out.
