### PR TITLE
Fix django settings module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ media/*
 settings/dev.py
 wsgi.py
 config/fabricrc
+.idea/

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "atlas.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Without this an exception is thrown when running `manage.py`. The old `atlas.settings` module doesn't exist anymore. More refrences to the old atlas name can be dropped to fix #947.
