### PR TITLE
Downgrade cmsplugin-filer version below 0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.5,<1.6
 django-localflavor
 South>=0.7.3
 Pillow>=1.7.8
-cmsplugin-filer>=0.8.0
+cmsplugin-filer<0.10
 # Install bleach before django-cms to use bleach's html5lib version dependency
 bleach
 django-cms>=2.4,<3.0


### PR DESCRIPTION
Without this patch the following error happens. 

![screenshot from 2015-01-29 01 09 25](https://cloud.githubusercontent.com/assets/2273055/5954146/24604310-a759-11e4-83a4-0ca6ea24a036.png)

Since we use django-cms 2.X we need to downgrade the version. This is [documented in the readme file](https://github.com/stefanfoulis/cmsplugin-filer).
